### PR TITLE
refactor: improve settings management with proper id and alias bindin…

### DIFF
--- a/Settings/Settings.qml
+++ b/Settings/Settings.qml
@@ -5,12 +5,13 @@ import Quickshell.Io
 import qs.Services
 
 Singleton {
+    id: settingParent
 
     property string shellName: "Noctalia"
     property string settingsDir: Quickshell.env("NOCTALIA_SETTINGS_DIR") || (Quickshell.env("XDG_CONFIG_HOME") || Quickshell.env("HOME") + "/.config") + "/" + shellName + "/"
     property string settingsFile: Quickshell.env("NOCTALIA_SETTINGS_FILE") || (settingsDir + "Settings.json")
     property string themeFile: Quickshell.env("NOCTALIA_THEME_FILE") || (settingsDir + "Theme.json")
-    property var settings: settingAdapter
+    property alias settings: settingAdapter
 
     Item {
         Component.onCompleted: {
@@ -21,7 +22,7 @@ Singleton {
 
     FileView {
         id: settingFileView
-        path: settingsFile
+        path: settingParent.settingsFile
         watchChanges: true
         onFileChanged: reload()
         onAdapterUpdated: writeAdapter()
@@ -51,7 +52,7 @@ Singleton {
             })
         }
         onLoadFailed: function(error) {
-            settingAdapter = {}
+            settingParent.settingsAdapter = {}
             writeAdapter()
         }
         JsonAdapter {


### PR DESCRIPTION

This pull request refactors the way settings are accessed and managed within the `Settings/Settings.qml` file, primarily by introducing a parent singleton reference and updating property and variable usage to improve clarity and maintainability.

Refactoring for clarity and maintainability:

* Added `id: settingParent` to the `Singleton` to provide a clear reference for accessing properties and methods throughout the file.
* Changed the `settings` property from a variable to a property alias, ensuring that it directly references `settingAdapter` for more consistent access.
* Updated references to `settingsFile` in `FileView` to use `settingParent.settingsFile`, making it explicit that the path comes from the singleton parent.
* Modified error handling in `onLoadFailed` to set `settingParent.settingsAdapter` instead of the previous local variable, aligning with the new parent-based structure.